### PR TITLE
Add Just livin’ the dream song page

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,3 +10,7 @@ CSB's music
 <p>
 
 <a href="songs/moose/">Big Moose Energy</a>
+
+<p>
+
+<a href="songs/dream/">Just livin’ the dream</a>

--- a/songs/dream/index.html
+++ b/songs/dream/index.html
@@ -1,0 +1,26 @@
+song: Just livin’ the dream<p>
+
+links:<p>
+
+<ol>
+<li> <a href="https://www.youtube.com/embed/lCNWXOCK6SM">YouTube</a>
+
+<li> <a href="https://x.com/CSB/status/1973471416516567524">X / Twitter</a>
+
+<li> <a href="https://www.instagram.com/reel/DPR5PFCDdz_/">Instagram</a>
+
+
+</ol>
+
+<p>embedded version, from YouTube:
+<p>
+
+<iframe width="315" height="560"
+src="https://www.youtube.com/embed/lCNWXOCK6SM?loop=1&playlist=lCNWXOCK6SM"
+title="YouTube video player" frameborder="0"
+allow="accelerometer; autoplay; clipboard-write; encrypted-media;
+gyroscope; picture-in-picture;
+web-share"
+allowfullscreen></iframe>
+
+


### PR DESCRIPTION
## Summary
- add a song page for "Just livin’ the dream" with external links and embedded YouTube player
- link the new song page from the main index

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68e405589e608325ac6ec8be152c90be