### PR TITLE
Align YouTube embed on Just livin’ the dream page

### DIFF
--- a/songs/dream/index.html
+++ b/songs/dream/index.html
@@ -15,12 +15,6 @@ links:<p>
 <p>embedded version, from YouTube:
 <p>
 
-<iframe width="315" height="560"
-src="https://www.youtube.com/embed/lCNWXOCK6SM?loop=1&playlist=lCNWXOCK6SM"
-title="YouTube video player" frameborder="0"
-allow="accelerometer; autoplay; clipboard-write; encrypted-media;
-gyroscope; picture-in-picture;
-web-share"
-allowfullscreen></iframe>
+<iframe width="420" height="345" src="https://www.youtube.com/embed/lCNWXOCK6SM?loop=1&playlist=lCNWXOCK6SM"></iframe>
 
 


### PR DESCRIPTION
## Summary
- update the "Just livin’ the dream" song page to use the same YouTube iframe markup as "Please Mr. McFinley"

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e4073539c083258e3b87fd7eda5e7e