### PR TITLE
Add Éclair Serenade song page

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,10 @@ CSB's music
 
 <p>
 
+<a href="songs/eclair/">Éclair Serenade</a>
+
+<p>
+
 <a href="songs/pom/">Please Mr. McFinley</a>
 
 <p>

--- a/songs/eclair/index.html
+++ b/songs/eclair/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<body>
+song: Éclair Serenade<p>
+
+links:<p>
+
+<ol>
+<li> <a href="https://www.youtube.com/shorts/Y1wllrE0saw">YouTube</a>
+
+<li> <a href="https://x.com/CSB/status/1870818997941461097">X / Twitter</a>
+
+<li> <a href="https://www.instagram.com/reel/DD-86zhNYl_/">Instagram</a>
+
+</ol>
+
+<p>embedded version, from YouTube:
+<p>
+<iframe width="315" height="560"
+src="https://www.youtube.com/embed/Y1wllrE0saw?loop=1&playlist=Y1wllrE0saw"
+title="YouTube video player" frameborder="0"
+allow="accelerometer; autoplay; clipboard-write; encrypted-media;
+gyroscope; picture-in-picture;
+web-share"
+allowfullscreen></iframe>
+
+<p>
+lyrics:
+<p>
+Coming soon.
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new Éclair Serenade song page with social links and embedded YouTube short
- link the Éclair Serenade page from the site index

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e413d97970832587ad603365e57c8f